### PR TITLE
Add HF integration

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -8,6 +8,8 @@ import numpy as np
 import torch
 from PIL import Image
 
+from huggingface_hub import PyTorchModelHubMixin
+
 from ultralytics.cfg import TASK2DATA, get_cfg, get_save_dir
 from ultralytics.engine.results import Results
 from ultralytics.hub import HUB_WEB_ROOT, HUBTrainingSession
@@ -26,7 +28,7 @@ from ultralytics.utils import (
 )
 
 
-class Model(nn.Module):
+class Model(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/ultralytics/ultralytics", pipeline_tag="object-detection", license="agpl-3.0"):
     """
     A base class for implementing YOLO models, unifying APIs across different model types.
 


### PR DESCRIPTION
Hi @sunsmarterjie,

Thanks for this nice work! I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the various YOLOv12 models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Here's a [notebook](https://colab.research.google.com/drive/12WSB8FnDS0sUEdmiNF2vPLqa_H1LCYtb?usp=sharing) to reproduce.

Usage is as follows:

```python
from ultralytics import YOLOv12

model = YOLOv10.from_pretrained("nielsr/yolov12n")

# optionally, one can push a trained model to the hub
model.push_to_hub("nielsr/my-awesome-yolov12-model")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. The corresponding model is here for now: https://huggingface.co/nielsr/yolov12n. We could move all checkpoints to separate repos to an organization on the hub or your personal user account if you're interested.

Fixes #10 

Would you be interested in this integration?

Kind regards,

Niels