### PR TITLE
Fix "Ray Tune Callback: Replace _get_session() with get_session()" (@jnx03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 </div>
 
-[![arXiv](https://img.shields.io/badge/arXiv-2502.12524-b31b1b.svg)](https://arxiv.org/abs/2502.12524) [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/sunsmarterjieleaf/yolov12) <a href="https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/train-yolov12-object-detection-model.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> [![deploy](https://media.roboflow.com/deploy.svg)](https://blog.roboflow.com/use-yolov12-with-roboflow/#deploy-yolov12-models-with-roboflow)
+[![arXiv](https://img.shields.io/badge/arXiv-2502.12524-b31b1b.svg)](https://arxiv.org/abs/2502.12524) [![Hugging Face Demo](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/sunsmarterjieleaf/yolov12) <a href="https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/train-yolov12-object-detection-model.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a> [![Kaggle Notebook](https://img.shields.io/badge/Kaggle-Notebook-blue?logo=kaggle)](https://www.kaggle.com/code/jxxn03x/yolov12-on-custom-data) [![deploy](https://media.roboflow.com/deploy.svg)](https://blog.roboflow.com/use-yolov12-with-roboflow/#deploy-yolov12-models-with-roboflow)
 
 ## Updates
 

--- a/ultralytics/utils/callbacks/raytune.py
+++ b/ultralytics/utils/callbacks/raytune.py
@@ -14,7 +14,7 @@ except (ImportError, AssertionError):
 
 def on_fit_epoch_end(trainer):
     """Sends training metrics to Ray Tune at end of each epoch."""
-    if ray.train._internal.session._get_session():  # replacement for deprecated ray.tune.is_session_enabled()
+    if ray.train._internal.session.get_session():  # replacement for deprecated ray.tune.is_session_enabled()
         metrics = trainer.metrics
         session.report({**metrics, **{"epoch": trainer.epoch + 1}})
 


### PR DESCRIPTION

This pull request resolves an `AttributeError` encountered during training when using newer versions of Ray. The error occurred because the callback in `ultralytics/utils/callbacks/raytune.py` was calling the deprecated method `_get_session()` (which has been removed or renamed in recent Ray releases) instead of the updated `get_session()`.

**Error come from google colab and kaggle notebook**

**Changes I Made:**  
- In the file `ultralytics/utils/callbacks/raytune.py`, update the call:
  ```python
  if ray.train._internal.session._get_session():
  ```
  to:
  ```python
  if ray.train._internal.session.get_session():
  ```
- This change ensures compatibility with Ray versions >=2.41.0.

**Testing:**  
- Verified that the training pipeline now runs without the AttributeError on Ray v2.41.0.
- Confirmed that callbacks reporting training metrics to Ray Tune work as expected.

**Additional Notes:**  
- Ray version can alternatively downgrade Ray (e.g., to version 2.40.0) as a temporary workaround.

Please review and merge if everything looks good.

---