### PR TITLE
Fix 'AAttn' object has no attribute 'qk' by adding supervision==0.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ py-cpuinfo==9.0.0
 huggingface-hub==0.23.2
 safetensors==0.4.3
 numpy==1.26.4
+supervision==0.22.0


### PR DESCRIPTION
Fixes #104 

Resolved the error 'AAttn' object has no attribute 'qk'. Did you mean: 'qkv'?' by adding supervision==0.22 to requirements.txt.