### PR TITLE
Fix tensor shape mismatch in AAttn when dim is not divisible by num_heads

### DIFF
--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1205,13 +1205,13 @@ class AAttn(nn.Module):
 
         self.num_heads = num_heads
         self.head_dim = head_dim = dim // num_heads
-        all_head_dim = head_dim * self.num_heads
+        self.all_head_dim = all_head_dim = head_dim * self.num_heads
 
         self.qk = Conv(dim, all_head_dim * 2, 1, act=False)
         self.v = Conv(dim, all_head_dim, 1, act=False)
         self.proj = Conv(all_head_dim, dim, 1, act=False)
 
-        self.pe = Conv(all_head_dim, dim, 5, 1, 2, g=dim, act=False)
+        self.pe = Conv(all_head_dim, all_head_dim, 5, 1, 2, g=all_head_dim, act=False)
 
 
     def forward(self, x):
@@ -1225,10 +1225,10 @@ class AAttn(nn.Module):
         v = v.flatten(2).transpose(1, 2)
 
         if self.area > 1:
-            qk = qk.reshape(B * self.area, N // self.area, C * 2)
-            v = v.reshape(B * self.area, N // self.area, C)
+            qk = qk.reshape(B * self.area, N // self.area, self.all_head_dim * 2)
+            v = v.reshape(B * self.area, N // self.area, self.all_head_dim)
             B, N, _ = qk.shape
-        q, k = qk.split([C, C], dim=2)
+        q, k = qk.split([self.all_head_dim, self.all_head_dim], dim=2)
 
         if x.is_cuda and USE_FLASH_ATTN:
             q = q.view(B, N, self.num_heads, self.head_dim)
@@ -1254,9 +1254,9 @@ class AAttn(nn.Module):
             x = x.permute(0, 3, 1, 2)
 
         if self.area > 1:
-            x = x.reshape(B // self.area, N * self.area, C)
+            x = x.reshape(B // self.area, N * self.area, self.all_head_dim)
             B, N, _ = x.shape
-        x = x.reshape(B, H, W, C).permute(0, 3, 1, 2)
+        x = x.reshape(B, H, W, self.all_head_dim).permute(0, 3, 1, 2)
 
         return self.proj(x + pp)
     


### PR DESCRIPTION
### Description

I noticed that the `AAttn` class attempts to handle cases where `dim` is not divisible by `num_heads` by defining the `all_head_dim` variable. However, the current implementation doesn't use it consistently, which leads to crashes in both initialization and forward passes.

Specifically, when `dim % num_heads != 0`, the original code encounters 3 critical issues:
1. **Initialization Crash (`ValueError`):** In `self.pe`, the module is initialized with `in_channels=all_head_dim` but `groups=dim`. This triggers `ValueError: in_channels must be divisible by groups`.
<img width="691" height="343" alt="2026-04-02 221235" src="https://github.com/user-attachments/assets/a0c5ed68-5236-4ce1-89d8-7ff03a33a8cb" />

2. **Reshape Crash (`RuntimeError`):** In the forward pass, `x` cannot be properly reshaped because it forces the use of the original `C` (`dim`) instead of the internally processed channel size.
<img width="735" height="193" alt="image" src="https://github.com/user-attachments/assets/763bd34c-7183-4145-b02e-4f524923dbcd" />

3. **Projection Dimension Mismatch:** The addition `x + pp` results in a tensor with `dim` channels, but the projection layer `self.proj` is initialized to accept an input of `all_head_dim` channels. Passing it to `self.proj(x)` inevitably triggers a dimension mismatch error during the forward pass.

### How this PR fixes it

This PR corrects the internal channel logic to consistently use the calculated `all_head_dim` (which resolves to `head_dim * num_heads`) for intermediate operations. 

- **No structural changes:** It does not change the final input/output shapes.
- **Logic preserved:** All underlying operations (group convolutions, dimensional transformations) are kept exactly as intended.
- **Robustness:** The code now successfully handles ANY `dim` input, fulfilling the original intent of defining `all_head_dim` and significantly improving the module's robustness for custom/lightweight model designs.

### Note on Reliability
This exact logic fix has been thoroughly tested and **already merged into the official Ultralytics repository** ([PR #24114](https://github.com/ultralytics/ultralytics/pull/24114)). I am submitting this PR to help keep the original research codebase robust and synchronized with industry standards.

---

### Minimum Reproducible Example (Before this PR)
```python
import torch

# This will crash immediately before this PR
model = AAttn(dim=18, num_heads=4, area=2)
input_tensor = torch.randn(1, 18, 8, 8)
output = model(input_tensor)
```
